### PR TITLE
Build VIM swap file name from complete path

### DIFF
--- a/vim/vimrc
+++ b/vim/vimrc
@@ -76,7 +76,7 @@ autocmd BufEnter * :syntax sync fromstart
 
 " Move Backup Files to ~/.vim/sessions
 set backupdir=~/.vim/sessions
-set dir=~/.vim/sessions
+set dir=~/.vim/sessions//
 
 " Remember cursor position
 au BufReadPost * if line("'\"") > 1 && line("'\"") <= line("$") | exe "normal! g`\"" | endif


### PR DESCRIPTION
I browsed through your vimrc and thought you might like this. Pretty handy if you are editing two files of the same file name which are located in different directories.

From the VIM help about the `directory` option:

```
- For Unix and Win32, if a directory ends in two path separators "//"
  or "\\", the swap file name will be built from the complete path to
  the file with all path separators substituted to percent '%' signs.
  This will ensure file name uniqueness in the preserve directory.
```
